### PR TITLE
[feature, #35] pass through options to underlying encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ Works fine under Node 11.3+, and might run under versions of node going back to 
       })
     })
 
+### Options
+
+See [encrypt.js#L661](https://github.com/cisco/node-jose/blob/master/lib/jwe/encrypt.js#L661)
+
+You can add `encrypt` options as follows:
+
+    const { encrypt, decrypt } = jose(privateKey, publicKey, {
+      format: 'compact'
+      protect: true,
+      // or any of the encrypt options than can be passed to JWE.createEncrypt.
+      // https://github.com/cisco/node-jose/blob/master/lib/jwe/encrypt.js#L661
+    })
+
 ## Issues
 
 Cisco's [node-jose](https://github.com/cisco/node-jose/issues) library has issues with **private keys with a passphrase** and cypher set. See [add support for passphrase in pem certificate](https://github.com/cisco/node-jose/issues/234).

--- a/src/utils/jose.js
+++ b/src/utils/jose.js
@@ -1,11 +1,11 @@
 const { JWE } = require('node-jose')
 const { encode, decode } = require('./base64')
 
-const jose = (privateKey, publicKey) => {
+const jose = (privateKey, publicKey, options = {}) => {
   const encrypt = async raw => {
     if (!raw) throw new Error('Missing raw data.')
     const buffer = Buffer.from(JSON.stringify(raw))
-    const encrypted = await JWE.createEncrypt(publicKey)
+    const encrypted = await JWE.createEncrypt(options, publicKey)
       .update(buffer)
       .final()
     return encode(encrypted)


### PR DESCRIPTION
As per request by @gschmottlach-xse in #35 

You can now add an optional options object to the main `jose` function. See README.md for details.
